### PR TITLE
Add PreambleElement, and Other DocumentClass.  Fixes #5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ mod equations;
 pub mod visitor;
 
 pub use errors::*;
-pub use document::{Document, DocumentClass, Element, Preamble};
+pub use document::{Document, DocumentClass, Element, Preamble, PreambleElement};
 pub use paragraph::{Paragraph, ParagraphElement};
 pub use section::Section;
 pub use lists::{List, ListKind, Item};

--- a/src/visitor/printer.rs
+++ b/src/visitor/printer.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use super::Visitor;
-use document::{Document, DocumentClass, Element, Preamble};
+use document::{Document, DocumentClass, Element, Preamble, PreambleElement};
 use equations::{Align, Equation};
 use errors::*;
 use lists::{Item, List};
@@ -96,7 +96,13 @@ where
 
     fn visit_preamble(&mut self, preamble: &Preamble) -> Result<()> {
         for item in preamble.iter() {
-            writeln!(self.writer, r"\usepackage{{{}}}", item)?;
+            match item {
+                PreambleElement::UsePackage{package: pkg, argument:None}
+                  => writeln!(self.writer, r"\usepackage{{{}}}", pkg)?,
+                PreambleElement::UsePackage{package: pkg, argument:Some(arg)}
+                  => writeln!(self.writer, r"\usepackage[{}]{{{}}}", arg, pkg)?,
+                PreambleElement::UserDefined(s) => writeln!(self.writer, r"{}", s)?,
+            }
         }
 
         if !preamble.is_empty() && (preamble.title.is_some() || preamble.author.is_some()) {


### PR DESCRIPTION
This is somewhat API changing, (besides the new fields/struct), it changes the iter function to iterate over PreambleElement, rather than the existing String.  I didn't bump the version however (looking at the previous version bumps), they seemed to be done after the fact.

  I used an option for fixing #5, rather than the structure layout that was given in that bug report.  If this needs any changes before hand feel free to either let me know, or in the case that it is just easier feel free to make changes directly...