### PR TITLE
Implement Extend trait on Document.preamble and Document

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -190,6 +190,14 @@ impl Display for DocumentClass {
     }
 }
 
+impl Extend<Element> for Document {
+    fn extend<T: IntoIterator<Item=Element>>(&mut self, iter:T) {
+    for elem in iter {
+      self.push(elem);
+    }
+  }
+}
+
 /// An element of the document's preamble.
 #[derive(Clone, Debug, PartialEq)]
 #[allow(missing_docs)]
@@ -257,4 +265,13 @@ impl Preamble {
         self.contents.push(element.into());
         self
     }
+
+}
+
+impl Extend<PreambleElement> for Preamble {
+    fn extend<T: IntoIterator<Item=PreambleElement>>(&mut self, iter:T) {
+    for elem in iter {
+      self.push(elem);
+    }
+  }
 }


### PR DESCRIPTION
I had a need to add a collection of elements, and had some trouble trying to do so using the
`push` function and convincing the borrow checker about self, I saw the Extend trait and implemented that,

I'm still somewhat new to using rust, so I'm not sure if this works as cohesively with
the rest of the library with regards to the `Into<PreambleElement>` trait or if I need change it to that.

Thanks.