### PR TITLE
Added Section::numbered to control whether or not a section title includes section numbers

### DIFF
--- a/src/section.rs
+++ b/src/section.rs
@@ -7,10 +7,12 @@ use document::Element;
 /// Like the `Document` type, a `Section` is more or less just a collection of
 /// `Element`s. When rendered it will start with `\section{Section Name}` and
 /// then each element will be rendered in turn.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Section {
     /// The name of the section.
     pub name: String,
+    /// Whether or not this section should include the section number.
+    pub numbered: bool,
     elements: Vec<Element>,
 }
 
@@ -21,6 +23,12 @@ impl Section {
             name: name.to_string(),
             ..Default::default()
         }
+    }
+
+    /// Sets whether or not this section should include the section number.
+    pub fn numbered(mut self, numbered: bool) -> Section {
+        self.numbered = numbered;
+        self
     }
 
     /// Add an element to the Section.
@@ -40,5 +48,15 @@ impl Section {
     /// Is this section empty?
     pub fn is_empty(&self) -> bool {
         self.elements.is_empty()
+    }
+}
+
+impl Default for Section {
+    fn default() -> Self {
+        Self {
+            name: "".into(),
+            numbered: true,
+            elements: Vec::new()
+        }
     }
 }

--- a/src/visitor/printer.rs
+++ b/src/visitor/printer.rs
@@ -186,7 +186,12 @@ where
     }
 
     fn visit_section(&mut self, section: &Section) -> Result<(), Error> {
-        writeln!(self.writer, r"\section{{{}}}", section.name)?;
+
+        if section.numbered {
+            writeln!(self.writer, r"\section{{{}}}", section.name)?;
+        } else {
+            writeln!(self.writer, r"\section*{{{}}}", section.name)?;
+        }
 
         if !section.is_empty() {
             // Make sure there's space between the \section{...} and the next line


### PR DESCRIPTION
Hiya! I just made a small change here to allow you to make non-numbered sections. (using `\section*` instead of `\section`) Figured I'd throw it here in case it's helpful. Cheers!